### PR TITLE
Alternative HTML example update

### DIFF
--- a/lib/assembleKssPlugin.js
+++ b/lib/assembleKssPlugin.js
@@ -86,7 +86,7 @@ function createHtmlIframeFilesForSection (sectionKey, section, options, pages) {
     };
 
     var alternativePage;
-    if(section.alternativeMarkup){
+    if (section.alternativeMarkup) {
       alternativePage = {
         data: {
           layout: options.alternativeTemplateIframe
@@ -100,7 +100,7 @@ function createHtmlIframeFilesForSection (sectionKey, section, options, pages) {
     firstPage.data = _.merge(firstPage.data, section);
 
     pages.push(firstPage);
-    if(section.alternativeMarkup){
+    if (section.alternativeMarkup) {
       pages.push(alternativePage);
     }
 
@@ -135,7 +135,7 @@ function createHtmlIframeFilesForSubsections (section, options, pages) {
       };
 
       var alternativeSubSectionPage;
-      if(subSection.alternativeMarkup){
+      if (subSection.alternativeMarkup) {
         alternativeSubSectionPage = {
           data: {
             layout: options.alternativeTemplateIframe
@@ -145,12 +145,11 @@ function createHtmlIframeFilesForSubsections (section, options, pages) {
         alternativeSubSectionPage.data = _.merge(alternativeSubSectionPage.data, subSection);
       }
 
-
       // merge the page data into the context
       subSectionPage.data = _.merge(subSectionPage.data, subSection);
 
       pages.push(subSectionPage);
-      if(subSection.alternativeMarkup){
+      if (subSection.alternativeMarkup) {
         pages.push(alternativeSubSectionPage);
       }
 
@@ -176,9 +175,9 @@ function createHtmlFileForSection (sectionData, sectionName, navBarItems, parent
   'use strict';
   var filePath;
 
-  if(sectionName !== 'index'){
+  if (sectionName !== 'index') {
     filePath = '/overview-' + sectionName.toLowerCase() + '.html';
-  }else{
+  } else {
     filePath = '/' + sectionName.toLowerCase() + '.html';
   }
 
@@ -232,6 +231,24 @@ function isSection (object) {
 }
 
 /**
+ * Sort sections object by alphabet
+ */
+function sortAlphabetically (dict) {
+  'use strict';
+
+  // sort array by alphabet
+  dict.sort(function (a, b) {
+    if (a.sectionName.toLowerCase() < b.sectionName.toLowerCase()) {
+      return -1;
+    } else if (a.sectionName.toLowerCase() > b.sectionName.toLowerCase()) {
+      return 1;
+    } else {
+      return 0;
+    }
+  });
+}
+
+/**
  * Get a list that holds all information necessary to display the navigation bar.
  * The list contains of first level navigation items and nested second level navigation items.
  * @param sections All sections of the style guide but with all information like markup, description and so
@@ -279,6 +296,9 @@ function getListOfNavBarItems (sections) {
           firstLevelNavItem.subSections.push(secondLevelNavItem);
         }
       }
+      // sort subsections alphabetically
+      sortAlphabetically(firstLevelNavItem.subSections);
+
       navBarItems[sectionKey] = firstLevelNavItem;
     }
   }
@@ -341,7 +361,9 @@ module.exports = function (params, callback) {
   _.extend(sections, pageSections);
 
   // write a file containing all sections and their data. This file is used by the search.
-  grunt.file.write(options.dataDestination + '/search-index.json', JSON.stringify(sections, null, 4));
+  if(options.dataDestination !== undefined){
+    grunt.file.write(options.dataDestination + '/search-index.json', JSON.stringify(sections, null, 4));
+  }
 
   var navBarItems = getListOfNavBarItems(sections);
 

--- a/lib/assembleKssPlugin.js
+++ b/lib/assembleKssPlugin.js
@@ -85,10 +85,24 @@ function createHtmlIframeFilesForSection (sectionKey, section, options, pages) {
       dest: options.dest + "/" + section.htmlFile,
     };
 
+    var alternativePage;
+    if(section.alternativeMarkup){
+      alternativePage = {
+        data: {
+          layout: options.alternativeTemplateIframe
+        },
+        dest: options.dest + "/" + section.alternativeHtmlFile,
+      };
+      alternativePage.data = _.merge(alternativePage.data, section);
+    }
+
     // merge the page data into the context
     firstPage.data = _.merge(firstPage.data, section);
 
     pages.push(firstPage);
+    if(section.alternativeMarkup){
+      pages.push(alternativePage);
+    }
 
     // recursively create html files for all subsections
     createHtmlIframeFilesForSubsections(section, options, pages);
@@ -120,10 +134,25 @@ function createHtmlIframeFilesForSubsections (section, options, pages) {
         dest: options.dest + "/" + subSection.htmlFile,
       };
 
+      var alternativeSubSectionPage;
+      if(subSection.alternativeMarkup){
+        alternativeSubSectionPage = {
+          data: {
+            layout: options.alternativeTemplateIframe
+          },
+          dest: options.dest + "/" + subSection.alternativeHtmlFile,
+        };
+        alternativeSubSectionPage.data = _.merge(alternativeSubSectionPage.data, subSection);
+      }
+
+
       // merge the page data into the context
       subSectionPage.data = _.merge(subSectionPage.data, subSection);
 
       pages.push(subSectionPage);
+      if(subSection.alternativeMarkup){
+        pages.push(alternativeSubSectionPage);
+      }
 
       // recursively create html files for all subsections
       createHtmlIframeFilesForSubsections(subSection, options, pages);
@@ -253,7 +282,6 @@ function getListOfNavBarItems (sections) {
       navBarItems[sectionKey] = firstLevelNavItem;
     }
   }
-  console.log(JSON.stringify(navBarItems, null, 4));
   return navBarItems;
 }
 

--- a/lib/handlebars-helpers/markupHelpers.js
+++ b/lib/handlebars-helpers/markupHelpers.js
@@ -6,7 +6,6 @@ module.exports.register = function (Handlebars)
      */
     Handlebars.registerHelper('markupWithStyle', function (modifierText, stateModifierText)
     {
-
         var context = this;
 
         if (!context || !context.markup)
@@ -51,6 +50,55 @@ module.exports.register = function (Handlebars)
         return html;
     });
 
+  /**
+   * Outputs the current section's or modifier's markup.
+   */
+  Handlebars.registerHelper('alternativeMarkupWithStyle', function (modifierText, stateModifierText)
+  {
+    var context = this;
+
+    if (!context || !context.alternativeMarkup)
+    {
+      return '';
+    }
+
+    if (typeof modifierText === "string")
+    {
+      if (!this.alternativeMarkupContext)
+      {
+        this.alternativeMarkupContext = {};
+      }
+      this.alternativeMarkupContext.modifier_class = modifierText;
+    }
+    if (typeof stateModifierText === "string")
+    {
+      if (!this.alternativeMarkupContext)
+      {
+        this.alternativeMarkupContext = {};
+      }
+      this.alternativeMarkupContext.stateModifier = stateModifierText;
+    }
+
+    var markup = context.alternativeMarkup;
+    var markupContext = context.alternativeMarkupContext;
+
+    var template;
+
+    if (markup.search(/.*\.hbs/gi) === 0)
+    {
+      var mName = markup.replace(".hbs", "");
+      template = Handlebars.compile('{{> "' + mName + '"}}');
+    } else
+    {
+      template = Handlebars.compile(markup);
+    }
+
+    var html = template(markupContext);
+    html = html.trim();
+
+    return html;
+  });
+
     Handlebars.registerHelper('displayMarkupPath', function ()
     {
         //Get src path by depending scss file path
@@ -76,6 +124,28 @@ module.exports.register = function (Handlebars)
         }
         return '';
     });
+
+    /**
+     * Returns the path to the alternative markup file.
+     */
+  Handlebars.registerHelper('displayAlternativeMarkupPath', function ()
+  {
+    //Get src path by depending scss file path
+    var regEx = /[^\/]*$/;
+    var path = "";
+    if (this.alternativeSrcPath)
+    {
+      path = this.alternativeSrcPath.replace(regEx, '');
+    }
+    if (this.alternativeMarkup)
+    {
+      if (this.alternativeMarkup.indexOf(".hbs") >= 0)
+      {
+        return path + this.alternativeMarkup;
+      }
+    }
+    return '';
+  });
 
     Handlebars.registerHelper('displayContextPath', function ()
     {

--- a/lib/kssCommentsParser.js
+++ b/lib/kssCommentsParser.js
@@ -48,6 +48,7 @@ kssCommentsParser.addSubSectionsToObject = function (subSections, parentSection,
   //check if this section name already exists before creating
   if (!parentSection[subSections[0]]) {
     var htmlFilePath;
+    var alternativeHtmlFilePath;
     var destinationPath;
     var sectionRef = 'sectionRef';
 
@@ -63,12 +64,14 @@ kssCommentsParser.addSubSectionsToObject = function (subSections, parentSection,
       // therefore give the html file the same name as the section
       // example: sectionabc-test/sectionabc-test.html
       htmlFilePath = currentSectionNameWithoutWhitespace + '_' + currentSectionNameWithoutWhitespace + '.html';
+      alternativeHtmlFilePath = 'alternative-' + currentSectionNameWithoutWhitespace + '_' + currentSectionNameWithoutWhitespace + '.html';
       destinationPath = './' + currentSectionNameWithoutWhitespace + '.html';
 
     } else if (parentSection.level > 1) {
       // otherwise the path for the html file is relative from the root section
       // example: sectionabc-test/some-sub-section/someFinalSection.html
       htmlFilePath = pathToRootSection + '_' + currentSectionNameWithoutWhitespace + '.html';
+      alternativeHtmlFilePath = 'alternative-' + pathToRootSection + '_' + currentSectionNameWithoutWhitespace + '.html';
 
       destinationPath = './' + baseHtmlFileName + '#' + sectionRef;
     }
@@ -77,6 +80,7 @@ kssCommentsParser.addSubSectionsToObject = function (subSections, parentSection,
       sectionName: currentSectionName,
       level: parentSection.level + 1,
       htmlFile: htmlFilePath,
+      alternativeHtmlFile: alternativeHtmlFilePath,
       sectionLocation: sectionRefs,
       sectionRef: sectionRef,
       destPath: destinationPath
@@ -333,6 +337,30 @@ kssCommentsParser.getSectionObjectOfKssComment = function (cssCommentPathObject,
       return false;
     });
 
+    // check if the comment contains alternative markup
+    var alternativeMarkup;
+    var commentContainsAlternativeMarkup = cssLines.some(function (element, index) {
+      var alternativeMarkupTest = new RegExp("alternative-markup:", "i").test(element);
+      if (alternativeMarkupTest) {
+        alternativeMarkup = element;
+        return true;
+      }
+      return false;
+    });
+    var alternativeScss;
+    var commentContainsAlternativeScss = cssLines.some(function (element, index) {
+      var alternativeScssTest = new RegExp("alternative-scss-file:", "i").test(element);
+      if (alternativeScssTest) {
+        alternativeScss = element.replace(/alternative-scss-file:/i, '').trim();
+        return true;
+      }
+      return false;
+    });
+    if (commentContainsAlternativeScss && alternativeScss) {
+      var alternativeSrcPath = srcPath.substring(0, srcPath.lastIndexOf("/") + 1);
+      sectionObject.alternativeSrcPath = alternativeSrcPath + alternativeScss;
+    }
+
     //get the description and remove from the lines
     var descriptionLines = [];//cssLines;
     if (commentContainsMarkup) {
@@ -453,10 +481,14 @@ kssCommentsParser.getSectionObjectOfKssComment = function (cssCommentPathObject,
     // test if anuglar-markup is available
     var angularMarkupAvailable = new RegExp("^\s*Angular-Markup:\s*", "i").test(markup);
 
-    var path, data;
+    var path, data, alternativePath, alternativeData;
     var jsonFileName;
+    var alternativeJsonFileName;
     if (sectionObject.properties && sectionObject.properties['json-file'] && sectionObject.properties['json-file'][0]) {
       jsonFileName = sectionObject.properties['json-file'][0];
+    }
+    if (sectionObject.properties && sectionObject.properties['alternative-json-file'] && sectionObject.properties['alternative-json-file'][0]) {
+      alternativeJsonFileName = sectionObject.properties['alternative-json-file'][0];
     }
     if (markupAvailable) {
       markup = markup.replace(/^\s*Markup:\s*/i, "");
@@ -542,6 +574,37 @@ kssCommentsParser.getSectionObjectOfKssComment = function (cssCommentPathObject,
         }
       }
     }
+
+    if (commentContainsAlternativeMarkup && alternativeMarkup !== undefined) {
+      alternativeMarkup = alternativeMarkup.replace(/^\s*alternative-Markup:\s*/i, "");
+      sectionObject.alternativeMarkup = alternativeMarkup.trim();
+
+      // if markup from hbs file add data context if available
+      if (alternativeMarkup.search(/.*\.hbs/gi) === 0) {
+
+        // use json file specified by json-file
+        if (alternativeJsonFileName) {
+          alternativePath = _getJSOJNPath(alternativeJsonFileName, srcPath);
+        } else {
+          alternativePath = _getJSOJNPath(alternativeMarkup, srcPath);
+        }
+        if (grunt.file.exists(alternativePath)) {
+          try {
+            alternativeData = grunt.file.readJSON(alternativePath);
+
+            if (alternativeData) {
+              sectionObject.alternativeMarkupContext = alternativeData;
+              sectionObject.alternativeMarkupContextPath = alternativeJsonFileName;
+            }
+          }
+          catch (exception) {
+            console.warn("cannot parse json file (" + alternativePath + ")");
+          }
+
+        }
+      }
+    }
+
     return sectionObject;
   }
   return -1;

--- a/lib/kssCommentsParser.js
+++ b/lib/kssCommentsParser.js
@@ -65,7 +65,7 @@ kssCommentsParser.addSubSectionsToObject = function (subSections, parentSection,
       // example: sectionabc-test/sectionabc-test.html
       htmlFilePath = currentSectionNameWithoutWhitespace + '_' + currentSectionNameWithoutWhitespace + '.html';
       alternativeHtmlFilePath = 'alternative-' + currentSectionNameWithoutWhitespace + '_' + currentSectionNameWithoutWhitespace + '.html';
-      destinationPath = './' + currentSectionNameWithoutWhitespace + '.html';
+      destinationPath = './' + 'overview-' + currentSectionNameWithoutWhitespace.replace(/\//, '') + '.html';
 
     } else if (parentSection.level > 1) {
       // otherwise the path for the html file is relative from the root section
@@ -73,7 +73,7 @@ kssCommentsParser.addSubSectionsToObject = function (subSections, parentSection,
       htmlFilePath = pathToRootSection + '_' + currentSectionNameWithoutWhitespace + '.html';
       alternativeHtmlFilePath = 'alternative-' + pathToRootSection + '_' + currentSectionNameWithoutWhitespace + '.html';
 
-      destinationPath = './' + baseHtmlFileName + '#' + sectionRef;
+      destinationPath = './' + 'overview-' + baseHtmlFileName.replace(/\//, '') + '#' + sectionRef;
     }
 
     parentSection[currentSectionName] = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-assemble-kss",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/actual/angular_angular.html
+++ b/test/actual/angular_angular.html
@@ -1,0 +1,53 @@
+    <link rel="stylesheet"
+          href="css/ergosign-style-guide.css">
+    <link rel="stylesheet"
+          href="css/documentation.css">
+    <link rel="stylesheet"
+          href="css/styles.css">
+
+    <div class="es-section-example-default">Default styling</div>
+<div
+    class="es-section-example-control">
+
+            
+</div><div class="es-section-example-variations">Variations:</div>
+    <div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.testVariation</div>
+                <div class="es-modifier__description">to test</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.testVariation.test2Variation</div>
+                <div class="es-modifier__description">two variation test</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">:hover</div>
+                <div class="es-modifier__description">with hover</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">:focus</div>
+                <div class="es-modifier__description">with focus</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.text:hover</div>
+                <div class="es-modifier__description">tricky</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+    </div>
+
+    <!-- TODO replace with your projects javascript file (only replace the name) -->
+    <script src="js/init-uxhub.min.js"></script>

--- a/test/actual/angularnewjson_angularnewjson.html
+++ b/test/actual/angularnewjson_angularnewjson.html
@@ -1,0 +1,53 @@
+    <link rel="stylesheet"
+          href="css/ergosign-style-guide.css">
+    <link rel="stylesheet"
+          href="css/documentation.css">
+    <link rel="stylesheet"
+          href="css/styles.css">
+
+    <div class="es-section-example-default">Default styling</div>
+<div
+    class="es-section-example-control">
+
+            
+</div><div class="es-section-example-variations">Variations:</div>
+    <div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.testVariation</div>
+                <div class="es-modifier__description">to test</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.testVariation.test2Variation</div>
+                <div class="es-modifier__description">two variation test</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">:hover</div>
+                <div class="es-modifier__description">with hover</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">:focus</div>
+                <div class="es-modifier__description">with focus</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.text:hover</div>
+                <div class="es-modifier__description">tricky</div>
+                <div class="es-modifier__example es-wrapper">
+                            
+                </div>
+            </div>
+    </div>
+
+    <!-- TODO replace with your projects javascript file (only replace the name) -->
+    <script src="js/init-uxhub.min.js"></script>

--- a/test/actual/data/search-index.json
+++ b/test/actual/data/search-index.json
@@ -66,7 +66,7 @@
                 "Test Section"
             ],
             "sectionRef": "sectionRef-test-section-newjsonpath",
-            "destPath": "./newjsonpath.html",
+            "destPath": "./overview-newjsonpath.html",
             "srcPath": "test/fixtures/scss/_test-section.scss",
             "sectionTitle": "Test Section new Json Path",
             "variations": [
@@ -128,7 +128,7 @@
                 "Test Section"
             ],
             "sectionRef": "sectionRef-test-section-newjsonpathout",
-            "destPath": "./newjsonpathout.html",
+            "destPath": "./overview-newjsonpathout.html",
             "srcPath": "test/fixtures/scss/_test-section.scss",
             "sectionTitle": "Test Section new Json Path out",
             "variations": [
@@ -190,7 +190,7 @@
                 "Test Section"
             ],
             "sectionRef": "sectionRef-test-section-angular",
-            "destPath": "./angular.html",
+            "destPath": "./overview-angular.html",
             "srcPath": "test/fixtures/scss/_test-section.scss",
             "sectionTitle": "Test Section Angular",
             "variations": [
@@ -258,7 +258,7 @@
                 "Test Section"
             ],
             "sectionRef": "sectionRef-test-section-angularnewjson",
-            "destPath": "./angularnewjson.html",
+            "destPath": "./overview-angularnewjson.html",
             "srcPath": "test/fixtures/scss/_test-section.scss",
             "sectionTitle": "Test Section Angular",
             "variations": [

--- a/test/actual/data/search-index.json
+++ b/test/actual/data/search-index.json
@@ -60,7 +60,8 @@
         "newjsonpath": {
             "sectionName": "newjsonpath",
             "level": 2,
-            "htmlFile": "newjsonpath/newjsonpath.html",
+            "htmlFile": "newjsonpath_newjsonpath.html",
+            "alternativeHtmlFile": "alternative-newjsonpath_newjsonpath.html",
             "sectionLocation": [
                 "Test Section"
             ],
@@ -121,7 +122,8 @@
         "newjsonpathout": {
             "sectionName": "newjsonpathout",
             "level": 2,
-            "htmlFile": "newjsonpathout/newjsonpathout.html",
+            "htmlFile": "newjsonpathout_newjsonpathout.html",
+            "alternativeHtmlFile": "alternative-newjsonpathout_newjsonpathout.html",
             "sectionLocation": [
                 "Test Section"
             ],
@@ -182,7 +184,8 @@
         "angular": {
             "sectionName": "angular",
             "level": 2,
-            "htmlFile": "angular/angular.html",
+            "htmlFile": "angular_angular.html",
+            "alternativeHtmlFile": "alternative-angular_angular.html",
             "sectionLocation": [
                 "Test Section"
             ],
@@ -249,7 +252,8 @@
         "angularnewjson": {
             "sectionName": "angularnewjson",
             "level": 2,
-            "htmlFile": "angularnewjson/angularnewjson.html",
+            "htmlFile": "angularnewjson_angularnewjson.html",
+            "alternativeHtmlFile": "alternative-angularnewjson_angularnewjson.html",
             "sectionLocation": [
                 "Test Section"
             ],

--- a/test/actual/index.html
+++ b/test/actual/index.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 7.5.2018</h3>
+                    <h3>Version  - 24.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -79,19 +79,19 @@
                                 <ul id="subsection-sectionabc-test"
                                     class="submenu-collapsed">
                                         <li class="">
-                                            <a href="newjsonpath.html">
+                                            <a href="overview-newjsonpath.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="newjsonpathout.html">
+                                            <a href="overview-newjsonpathout.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="angular.html">
+                                            <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="angularnewjson.html">
+                                            <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                 </ul>

--- a/test/actual/index.html
+++ b/test/actual/index.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 24.10.2018</h3>
+                    <h3>Version  - 27.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -79,20 +79,20 @@
                                 <ul id="subsection-sectionabc-test"
                                     class="submenu-collapsed">
                                         <li class="">
-                                            <a href="overview-newjsonpath.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
-                                        </li>
-                                        <li class="">
-                                            <a href="overview-newjsonpathout.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
-                                        </li>
-                                        <li class="">
                                             <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                         <li class="">
                                             <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
+                                        </li>
+                                        <li class="">
+                                            <a href="overview-newjsonpath.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
+                                        </li>
+                                        <li class="">
+                                            <a href="overview-newjsonpathout.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
                                 </ul>
                             </li>

--- a/test/actual/newjsonpath_newjsonpath.html
+++ b/test/actual/newjsonpath_newjsonpath.html
@@ -1,0 +1,65 @@
+    <link rel="stylesheet"
+          href="css/ergosign-style-guide.css">
+    <link rel="stylesheet"
+          href="css/documentation.css">
+    <link rel="stylesheet"
+          href="css/styles.css">
+
+    <div class="es-section-example-default">Default styling</div>
+<div
+    class="es-section-example-control">
+
+            <div class="doesthiswork ">
+    <a href="#12345">BIG TEXT NEW JSON</a>
+</div>
+</div><div class="es-section-example-variations">Variations:</div>
+    <div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.testVariation</div>
+                <div class="es-modifier__description">to test</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork testVariation">
+    <a href="#12345">BIG TEXT NEW JSON</a>
+</div>
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.testVariation.test2Variation</div>
+                <div class="es-modifier__description">two variation test</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork testVariation test2Variation">
+    <a href="#12345">BIG TEXT NEW JSON</a>
+</div>
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">:hover</div>
+                <div class="es-modifier__description">with hover</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork pseudo-class-hover">
+    <a href="#12345">BIG TEXT NEW JSON</a>
+</div>
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">:focus</div>
+                <div class="es-modifier__description">with focus</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork pseudo-class-focus">
+    <a href="#12345">BIG TEXT NEW JSON</a>
+</div>
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.text:hover</div>
+                <div class="es-modifier__description">tricky</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork text pseudo-class-hover">
+    <a href="#12345">BIG TEXT NEW JSON</a>
+</div>
+                </div>
+            </div>
+    </div>
+
+    <!-- TODO replace with your projects javascript file (only replace the name) -->
+    <script src="js/init-uxhub.min.js"></script>

--- a/test/actual/newjsonpathout_newjsonpathout.html
+++ b/test/actual/newjsonpathout_newjsonpathout.html
@@ -1,0 +1,65 @@
+    <link rel="stylesheet"
+          href="css/ergosign-style-guide.css">
+    <link rel="stylesheet"
+          href="css/documentation.css">
+    <link rel="stylesheet"
+          href="css/styles.css">
+
+    <div class="es-section-example-default">Default styling</div>
+<div
+    class="es-section-example-control">
+
+            <div class="doesthiswork ">
+    <a href="#12345">BIG TEXT NEW out</a>
+</div>
+</div><div class="es-section-example-variations">Variations:</div>
+    <div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.testVariation</div>
+                <div class="es-modifier__description">to test</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork testVariation">
+    <a href="#12345">BIG TEXT NEW out</a>
+</div>
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.testVariation.test2Variation</div>
+                <div class="es-modifier__description">two variation test</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork testVariation test2Variation">
+    <a href="#12345">BIG TEXT NEW out</a>
+</div>
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">:hover</div>
+                <div class="es-modifier__description">with hover</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork pseudo-class-hover">
+    <a href="#12345">BIG TEXT NEW out</a>
+</div>
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">:focus</div>
+                <div class="es-modifier__description">with focus</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork pseudo-class-focus">
+    <a href="#12345">BIG TEXT NEW out</a>
+</div>
+                </div>
+            </div>
+            <div class="es-modifier__container">
+                <div class="es-modifier__name">.text:hover</div>
+                <div class="es-modifier__description">tricky</div>
+                <div class="es-modifier__example es-wrapper">
+                            <div class="doesthiswork text pseudo-class-hover">
+    <a href="#12345">BIG TEXT NEW out</a>
+</div>
+                </div>
+            </div>
+    </div>
+
+    <!-- TODO replace with your projects javascript file (only replace the name) -->
+    <script src="js/init-uxhub.min.js"></script>

--- a/test/actual/overview-angular.html
+++ b/test/actual/overview-angular.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 24.10.2018</h3>
+                    <h3>Version  - 27.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -78,14 +78,6 @@
                                     <span class="es-mainnav-title">Test Section</span></a>
                                 <ul id="subsection-sectionabc-test"
                                     class=" ">
-                                        <li class="">
-                                            <a href="overview-newjsonpath.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
-                                        </li>
-                                        <li class="">
-                                            <a href="overview-newjsonpathout.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
-                                        </li>
                                         <li class="es-active-subsection">
                                             <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
@@ -93,6 +85,14 @@
                                         <li class="">
                                             <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
+                                        </li>
+                                        <li class="">
+                                            <a href="overview-newjsonpath.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
+                                        </li>
+                                        <li class="">
+                                            <a href="overview-newjsonpathout.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
                                 </ul>
                             </li>

--- a/test/actual/overview-angular.html
+++ b/test/actual/overview-angular.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 7.5.2018</h3>
+                    <h3>Version  - 24.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -79,19 +79,19 @@
                                 <ul id="subsection-sectionabc-test"
                                     class=" ">
                                         <li class="">
-                                            <a href="newjsonpath.html">
+                                            <a href="overview-newjsonpath.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
                                         </li>
-                                        <li class="es-active-subsection">
-                                            <a href="newjsonpathout.html">
+                                        <li class="">
+                                            <a href="overview-newjsonpathout.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
-                                        <li class="">
-                                            <a href="angular.html">
+                                        <li class="es-active-subsection">
+                                            <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="angularnewjson.html">
+                                            <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                 </ul>
@@ -106,8 +106,8 @@
 
                     <div class="es-section-title">
                         <div class="es-section-anchor"
-                             id="sectionRef-test-section-newjsonpathout"></div>
-                        <h2>Test Section new Json Path out</h2>
+                             id="sectionRef-test-section-angular"></div>
+                        <h2>Test Section Angular</h2>
                     </div>
 
 
@@ -117,84 +117,44 @@
 
                 </div>
 
-                <div class="es-section-example">
-                    <div>
-                            <div class="es-section-example-toggle">
-                                <div class="es-section-example-toggle-title">Example</div>
-                                <form>
-                                    <input type="radio"
-                                           name="rb-iframe"
-                                           checked>
-                                    <button class="es-section-example-iframe-toggle-button"
-                                            data-iframe="smartphone">
-                                        <span class="es-ico ico-smartphone"></span>
-                                    </button>
+                    <div class="es-section-example">
 
-                                    <input type="radio"
-                                           name="rb-iframe">
-                                    <button class="es-section-example-iframe-toggle-button"
-                                            data-iframe="tablet">
-                                        <span class="es-ico ico-tablet"></span>
-                                    </button>
-                                    <input type="radio"
-                                           name="rb-iframe">
-                                    <button class="es-section-example-iframe-toggle-button"
-                                            data-iframe="laptop">
-                                        <span class="es-ico ico-system"></span>
-                                    </button>
-                                    <input type="radio"
-                                           name="rb-iframe">
-                                    <button class="es-section-example-iframe-toggle-button"
-                                            data-iframe="all">
-                                        <span class="es-ico ico-placeholder"></span>
-                                    </button>
-                                </form>
-                            </div>
-
-                            <div class="es-section-example-srcpath">
-                                <a href="test/fixtures/scss/_test-section.scss">test/fixtures/scss/_test-section.scss</a>
-                            </div>
-
-
-                            <iframe class="iframe-smartphone iframe-visible"
-                                    data-iframe="smartphone"
-                                    style="
-                                        "
-                                    src='newjsonpathout/newjsonpathout.html'></iframe>
-
-
-                            <iframe class="iframe-tablet"
-                                    data-iframe="tablet"
-                                    src='newjsonpathout/newjsonpathout.html'
-                                    style="height: ;
-                                        "></iframe>
-                            <iframe class="iframe-laptop"
-                                    data-iframe="laptop"
-                                    src='newjsonpathout/newjsonpathout.html'
-                                    style="height: ;
-                                        "></iframe>
-
-                    </div>
+                        <styleguide-angular-component 
+                            variations='[{&quot;variationName&quot;:&quot;.testVariation&quot;,&quot;variationDescription&quot;:&quot;to test&quot;,&quot;variationClass&quot;:[&quot;testVariation&quot;]},{&quot;variationName&quot;:&quot;.testVariation.test2Variation&quot;,&quot;variationDescription&quot;:&quot;two variation test&quot;,&quot;variationClass&quot;:[&quot;testVariation&quot;,&quot;test2Variation&quot;]},{&quot;variationName&quot;:&quot;:hover&quot;,&quot;variationDescription&quot;:&quot;with hover&quot;,&quot;variationClass&quot;:[&quot;pseudo-class-hover&quot;]},{&quot;variationName&quot;:&quot;:focus&quot;,&quot;variationDescription&quot;:&quot;with focus&quot;,&quot;variationClass&quot;:[&quot;pseudo-class-focus&quot;]},{&quot;variationName&quot;:&quot;.text:hover&quot;,&quot;variationDescription&quot;:&quot;tricky&quot;,&quot;variationClass&quot;:[&quot;text&quot;,&quot;pseudo-class-hover&quot;]}]'
+                            wrapper-classes='"es-section-example-control"'
+                            directive-scope='{&quot;customize&quot;:false,&quot;widget&quot;:{&quot;size&quot;:&quot;m&quot;,&quot;icon&quot;:&quot;icon-alert&quot;,&quot;topText&quot;:&quot;Toptext&quot;,&quot;bottomText&quot;:&quot;bottom text&quot;}}'
+                        >
+                                <html-wrapper>
+                                    <xmp><div class="widget-wrapper"></div></xmp>
+                                </html-wrapper>
+                            <directive-markup>
+                                <xmp><still-widget widget="widget" customize="customize"></still-widget></xmp>
+                            </directive-markup>
+                        </styleguide-angular-component>
 
                         <div class="es-section-markup es-section-markup--collapsed">
-                            <div class="es-section-markup-togglebtn"><span class="es-ico ico-disclosuredown"></span>HTML
+                            <div class="es-section-markup-togglebtn"><span class="es-ico ico-disclosuredown"></span>Angular
+                                HTML
                             </div>
+                            <div class="es-section-markup-srcpath">test/fixtures/scss/simple-test-angular.html
 
-                            <div class="es-section-markup-codebox">
-                    <pre class="prettyprint linenums lang-html"><code
-                        data-language="html">&lt;div class&#x3D;&quot;doesthiswork [modifier_class]&quot;&gt;
-    &lt;a href&#x3D;&quot;#12345&quot;&gt;BIG TEXT NEW out&lt;/a&gt;
-&lt;/div&gt;</code><div class="es-section-markup-divider"></div></pre>
-                                <button class="codebox-copy-button"
-                                        data-clipboard-text="&lt;div class&#x3D;&quot;doesthiswork [modifier_class]&quot;&gt;
-    &lt;a href&#x3D;&quot;#12345&quot;&gt;BIG TEXT NEW out&lt;/a&gt;
-&lt;/div&gt;">
-                                    <span class="es-ico ico-copy"></span></button>
                             </div>
-                            <div class="es-section-markup-srcpath">test/fixtures/scss/simple-test.hbs
+                            <div class="es-section-markup-codebox">
+                                <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;still-widget widget&#x3D;&quot;widget&quot; customize&#x3D;&quot;customize&quot;&gt;&lt;/still-widget&gt; </code></pre>
                             </div>
                         </div>
- 
+                        <div class="es-section-markup es-section-markup--collapsed">
+                            <div class="es-section-markup-togglebtn"><span class="es-ico ico-disclosuredown"></span>Angular
+                                Context
+                            </div>
+                            <div class="es-section-markup-srcpath">
+                            </div>
+                            <div class="es-section-markup-codebox">
+                        <pre class="prettyprint linenums lang-js"><code
+                            data-language="js">{&quot;customize&quot;:false,&quot;widget&quot;:{&quot;size&quot;:&quot;m&quot;,&quot;icon&quot;:&quot;icon-alert&quot;,&quot;topText&quot;:&quot;Toptext&quot;,&quot;bottomText&quot;:&quot;bottom text&quot;}} </code></pre>
+                            </div>
+                        </div>
+                 
 
                     </section>
         </article>

--- a/test/actual/overview-angularnewjson.html
+++ b/test/actual/overview-angularnewjson.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 7.5.2018</h3>
+                    <h3>Version  - 24.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -79,19 +79,19 @@
                                 <ul id="subsection-sectionabc-test"
                                     class=" ">
                                         <li class="">
-                                            <a href="newjsonpath.html">
+                                            <a href="overview-newjsonpath.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="newjsonpathout.html">
+                                            <a href="overview-newjsonpathout.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="angular.html">
+                                            <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                         <li class="es-active-subsection">
-                                            <a href="angularnewjson.html">
+                                            <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                 </ul>

--- a/test/actual/overview-angularnewjson.html
+++ b/test/actual/overview-angularnewjson.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 24.10.2018</h3>
+                    <h3>Version  - 27.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -79,20 +79,20 @@
                                 <ul id="subsection-sectionabc-test"
                                     class=" ">
                                         <li class="">
-                                            <a href="overview-newjsonpath.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
-                                        </li>
-                                        <li class="">
-                                            <a href="overview-newjsonpathout.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
-                                        </li>
-                                        <li class="">
                                             <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                         <li class="es-active-subsection">
                                             <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
+                                        </li>
+                                        <li class="">
+                                            <a href="overview-newjsonpath.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
+                                        </li>
+                                        <li class="">
+                                            <a href="overview-newjsonpathout.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
                                 </ul>
                             </li>

--- a/test/actual/overview-newjsonpath.html
+++ b/test/actual/overview-newjsonpath.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 7.5.2018</h3>
+                    <h3>Version  - 24.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -78,20 +78,20 @@
                                     <span class="es-mainnav-title">Test Section</span></a>
                                 <ul id="subsection-sectionabc-test"
                                     class=" ">
-                                        <li class="">
-                                            <a href="newjsonpath.html">
+                                        <li class="es-active-subsection">
+                                            <a href="overview-newjsonpath.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="newjsonpathout.html">
+                                            <a href="overview-newjsonpathout.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
-                                        <li class="es-active-subsection">
-                                            <a href="angular.html">
+                                        <li class="">
+                                            <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="angularnewjson.html">
+                                            <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                 </ul>
@@ -106,8 +106,8 @@
 
                     <div class="es-section-title">
                         <div class="es-section-anchor"
-                             id="sectionRef-test-section-angular"></div>
-                        <h2>Test Section Angular</h2>
+                             id="sectionRef-test-section-newjsonpath"></div>
+                        <h2>Test Section new Json Path</h2>
                     </div>
 
 
@@ -117,44 +117,84 @@
 
                 </div>
 
-                    <div class="es-section-example">
+                <div class="es-section-example">
+                    <div>
+                            <div class="es-section-example-toggle">
+                                <div class="es-section-example-toggle-title">Example</div>
+                                <form>
+                                    <input type="radio"
+                                           name="rb-iframe"
+                                           checked>
+                                    <button class="es-section-example-iframe-toggle-button"
+                                            data-iframe="smartphone">
+                                        <span class="es-ico ico-smartphone"></span>
+                                    </button>
 
-                        <styleguide-angular-component
-                            variations='[{&quot;variationName&quot;:&quot;.testVariation&quot;,&quot;variationDescription&quot;:&quot;to test&quot;,&quot;variationClass&quot;:[&quot;testVariation&quot;]},{&quot;variationName&quot;:&quot;.testVariation.test2Variation&quot;,&quot;variationDescription&quot;:&quot;two variation test&quot;,&quot;variationClass&quot;:[&quot;testVariation&quot;,&quot;test2Variation&quot;]},{&quot;variationName&quot;:&quot;:hover&quot;,&quot;variationDescription&quot;:&quot;with hover&quot;,&quot;variationClass&quot;:[&quot;pseudo-class-hover&quot;]},{&quot;variationName&quot;:&quot;:focus&quot;,&quot;variationDescription&quot;:&quot;with focus&quot;,&quot;variationClass&quot;:[&quot;pseudo-class-focus&quot;]},{&quot;variationName&quot;:&quot;.text:hover&quot;,&quot;variationDescription&quot;:&quot;tricky&quot;,&quot;variationClass&quot;:[&quot;text&quot;,&quot;pseudo-class-hover&quot;]}]'
-                            wrapper-classes='"es-section-example-control"'
-                            directive-scope='{&quot;customize&quot;:false,&quot;widget&quot;:{&quot;size&quot;:&quot;m&quot;,&quot;icon&quot;:&quot;icon-alert&quot;,&quot;topText&quot;:&quot;Toptext&quot;,&quot;bottomText&quot;:&quot;bottom text&quot;}}'
-                        >
-                                <html-wrapper>
-                                    <xmp><div class="widget-wrapper"></div></xmp>
-                                </html-wrapper>
-                            <directive-markup>
-                                <xmp><still-widget widget="widget" customize="customize"></still-widget></xmp>
-                            </directive-markup>
-                        </styleguide-angular-component>
+                                    <input type="radio"
+                                           name="rb-iframe">
+                                    <button class="es-section-example-iframe-toggle-button"
+                                            data-iframe="tablet">
+                                        <span class="es-ico ico-tablet"></span>
+                                    </button>
+                                    <input type="radio"
+                                           name="rb-iframe">
+                                    <button class="es-section-example-iframe-toggle-button"
+                                            data-iframe="laptop">
+                                        <span class="es-ico ico-system"></span>
+                                    </button>
+                                    <input type="radio"
+                                           name="rb-iframe">
+                                    <button class="es-section-example-iframe-toggle-button"
+                                            data-iframe="all">
+                                        <span class="es-ico ico-placeholder"></span>
+                                    </button>
+                                </form>
+                            </div>
+
+                            <div class="es-section-example-srcpath">
+                                <a href="test/fixtures/scss/_test-section.scss">test/fixtures/scss/_test-section.scss</a>
+                            </div>
+
+
+                            <iframe class="iframe-smartphone iframe-visible"
+                                    data-iframe="smartphone"
+                                    style="
+                                        "
+                                    src='newjsonpath_newjsonpath.html'></iframe>
+
+
+                            <iframe class="iframe-tablet"
+                                    data-iframe="tablet"
+                                    src='newjsonpath_newjsonpath.html'
+                                    style="height: ;
+                                        "></iframe>
+                            <iframe class="iframe-laptop"
+                                    data-iframe="laptop"
+                                    src='newjsonpath_newjsonpath.html'
+                                    style="height: ;
+                                        "></iframe>
+
+                    </div>
 
                         <div class="es-section-markup es-section-markup--collapsed">
-                            <div class="es-section-markup-togglebtn"><span class="es-ico ico-disclosuredown"></span>Angular
-                                HTML
+                            <div class="es-section-markup-togglebtn"><span class="es-ico ico-disclosuredown"></span>HTML
                             </div>
-                            <div class="es-section-markup-srcpath">test/fixtures/scss/simple-test-angular.html
 
-                            </div>
                             <div class="es-section-markup-codebox">
-                                <pre class="prettyprint linenums lang-html"><code data-language="html">&lt;still-widget widget&#x3D;&quot;widget&quot; customize&#x3D;&quot;customize&quot;&gt;&lt;/still-widget&gt; </code></pre>
+                    <pre class="prettyprint linenums lang-html"><code
+                        data-language="html">&lt;div class&#x3D;&quot;doesthiswork [modifier_class]&quot;&gt;
+    &lt;a href&#x3D;&quot;#12345&quot;&gt;BIG TEXT NEW JSON&lt;/a&gt;
+&lt;/div&gt;</code><div class="es-section-markup-divider"></div></pre>
+                                <button class="codebox-copy-button"
+                                        data-clipboard-text="&lt;div class&#x3D;&quot;doesthiswork [modifier_class]&quot;&gt;
+    &lt;a href&#x3D;&quot;#12345&quot;&gt;BIG TEXT NEW JSON&lt;/a&gt;
+&lt;/div&gt;">
+                                    <span class="es-ico ico-copy"></span></button>
+                            </div>
+                            <div class="es-section-markup-srcpath">test/fixtures/scss/simple-test.hbs
                             </div>
                         </div>
-                        <div class="es-section-markup es-section-markup--collapsed">
-                            <div class="es-section-markup-togglebtn"><span class="es-ico ico-disclosuredown"></span>Angular
-                                Context
-                            </div>
-                            <div class="es-section-markup-srcpath">
-                            </div>
-                            <div class="es-section-markup-codebox">
-                        <pre class="prettyprint linenums lang-js"><code
-                            data-language="js">{&quot;customize&quot;:false,&quot;widget&quot;:{&quot;size&quot;:&quot;m&quot;,&quot;icon&quot;:&quot;icon-alert&quot;,&quot;topText&quot;:&quot;Toptext&quot;,&quot;bottomText&quot;:&quot;bottom text&quot;}} </code></pre>
-                            </div>
-                        </div>
-
+ 
 
                     </section>
         </article>
@@ -175,7 +215,7 @@
 
         <div class="modal-dialog"></div>
 
-
+        
     </body>
 
 </html>

--- a/test/actual/overview-newjsonpath.html
+++ b/test/actual/overview-newjsonpath.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 24.10.2018</h3>
+                    <h3>Version  - 27.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -78,14 +78,6 @@
                                     <span class="es-mainnav-title">Test Section</span></a>
                                 <ul id="subsection-sectionabc-test"
                                     class=" ">
-                                        <li class="es-active-subsection">
-                                            <a href="overview-newjsonpath.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
-                                        </li>
-                                        <li class="">
-                                            <a href="overview-newjsonpathout.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
-                                        </li>
                                         <li class="">
                                             <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
@@ -93,6 +85,14 @@
                                         <li class="">
                                             <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
+                                        </li>
+                                        <li class="es-active-subsection">
+                                            <a href="overview-newjsonpath.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
+                                        </li>
+                                        <li class="">
+                                            <a href="overview-newjsonpathout.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
                                 </ul>
                             </li>

--- a/test/actual/overview-newjsonpathout.html
+++ b/test/actual/overview-newjsonpathout.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 7.5.2018</h3>
+                    <h3>Version  - 24.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -78,20 +78,20 @@
                                     <span class="es-mainnav-title">Test Section</span></a>
                                 <ul id="subsection-sectionabc-test"
                                     class=" ">
-                                        <li class="es-active-subsection">
-                                            <a href="newjsonpath.html">
+                                        <li class="">
+                                            <a href="overview-newjsonpath.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
                                         </li>
-                                        <li class="">
-                                            <a href="newjsonpathout.html">
+                                        <li class="es-active-subsection">
+                                            <a href="overview-newjsonpathout.html">
                                                 <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="angular.html">
+                                            <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                         <li class="">
-                                            <a href="angularnewjson.html">
+                                            <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                 </ul>
@@ -106,8 +106,8 @@
 
                     <div class="es-section-title">
                         <div class="es-section-anchor"
-                             id="sectionRef-test-section-newjsonpath"></div>
-                        <h2>Test Section new Json Path</h2>
+                             id="sectionRef-test-section-newjsonpathout"></div>
+                        <h2>Test Section new Json Path out</h2>
                     </div>
 
 
@@ -160,17 +160,17 @@
                                     data-iframe="smartphone"
                                     style="
                                         "
-                                    src='newjsonpath/newjsonpath.html'></iframe>
+                                    src='newjsonpathout_newjsonpathout.html'></iframe>
 
 
                             <iframe class="iframe-tablet"
                                     data-iframe="tablet"
-                                    src='newjsonpath/newjsonpath.html'
+                                    src='newjsonpathout_newjsonpathout.html'
                                     style="height: ;
                                         "></iframe>
                             <iframe class="iframe-laptop"
                                     data-iframe="laptop"
-                                    src='newjsonpath/newjsonpath.html'
+                                    src='newjsonpathout_newjsonpathout.html'
                                     style="height: ;
                                         "></iframe>
 
@@ -183,11 +183,11 @@
                             <div class="es-section-markup-codebox">
                     <pre class="prettyprint linenums lang-html"><code
                         data-language="html">&lt;div class&#x3D;&quot;doesthiswork [modifier_class]&quot;&gt;
-    &lt;a href&#x3D;&quot;#12345&quot;&gt;BIG TEXT NEW JSON&lt;/a&gt;
+    &lt;a href&#x3D;&quot;#12345&quot;&gt;BIG TEXT NEW out&lt;/a&gt;
 &lt;/div&gt;</code><div class="es-section-markup-divider"></div></pre>
                                 <button class="codebox-copy-button"
                                         data-clipboard-text="&lt;div class&#x3D;&quot;doesthiswork [modifier_class]&quot;&gt;
-    &lt;a href&#x3D;&quot;#12345&quot;&gt;BIG TEXT NEW JSON&lt;/a&gt;
+    &lt;a href&#x3D;&quot;#12345&quot;&gt;BIG TEXT NEW out&lt;/a&gt;
 &lt;/div&gt;">
                                     <span class="es-ico ico-copy"></span></button>
                             </div>

--- a/test/actual/overview-newjsonpathout.html
+++ b/test/actual/overview-newjsonpathout.html
@@ -34,7 +34,7 @@
             <div class="es-header-inner">
                 <div class="es-header-headline">
                     <h2> - </h2>
-                    <h3>Version  - 24.10.2018</h3>
+                    <h3>Version  - 27.10.2018</h3>
                 </div>
                 <div class="es-header-search-bar-wrapper es-search-collapsed">
                     <div class="es-header-search-bar">
@@ -79,20 +79,20 @@
                                 <ul id="subsection-sectionabc-test"
                                     class=" ">
                                         <li class="">
-                                            <a href="overview-newjsonpath.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
-                                        </li>
-                                        <li class="es-active-subsection">
-                                            <a href="overview-newjsonpathout.html">
-                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
-                                        </li>
-                                        <li class="">
                                             <a href="overview-angular.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
                                         </li>
                                         <li class="">
                                             <a href="overview-angularnewjson.html">
                                                 <span class="es-mainnav-subtitle">Test Section Angular</span></a>
+                                        </li>
+                                        <li class="">
+                                            <a href="overview-newjsonpath.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path</span></a>
+                                        </li>
+                                        <li class="es-active-subsection">
+                                            <a href="overview-newjsonpathout.html">
+                                                <span class="es-mainnav-subtitle">Test Section new Json Path out</span></a>
                                         </li>
                                 </ul>
                             </li>


### PR DESCRIPTION
These changes enable the rendering of a second html example for a single css comment. This is necessary for the init project where the bootstrap controls need to be rendered right after the vanilla control.